### PR TITLE
Add SBOM fetching plugins for Maven and Gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
 fips/java/target/
+sbom-maven-plugin/target/
+sbom-maven-plugin/example/target/
+sbom-gradle-plugin/.gradle/
+sbom-gradle-plugin/build/
+sbom-gradle-plugin/example/.gradle/
+sbom-gradle-plugin/example/build/
 
 # Terraform
 **/*.tfvars

--- a/sbom-gradle-plugin/README.md
+++ b/sbom-gradle-plugin/README.md
@@ -14,9 +14,11 @@ See [Example](#example) for an example that demonstrates how the plugin works.
 To use this plugin you must either build it locally, or host it yourself in your
 own plugin repository (Artifactory, Nexus etc).
 
+Export a Chainguard pull token (see [Prerequisites](#prerequisites)), then:
+
 ```
-gradle test                # unit tests
-gradle publishToMavenLocal # install to ~/.m2/repository so mavenLocal() finds it
+gradle -I init.gradle test                # unit tests
+gradle -I init.gradle publishToMavenLocal # install to ~/.m2/repository so mavenLocal() finds it
 ```
 
 Then, apply it in your `build.gradle` like:
@@ -82,7 +84,7 @@ The example's `build.gradle` reads them from there.
 **2. Build and publish the plugin into your local Maven cache.**
 
 ```
-gradle publishToMavenLocal
+gradle -I init.gradle publishToMavenLocal
 ```
 
 **3. Change into the example project and run the plugin.**

--- a/sbom-gradle-plugin/README.md
+++ b/sbom-gradle-plugin/README.md
@@ -98,11 +98,12 @@ You should see something like:
 
 ```
 > Task :collectSboms
-Resolving SBOMs for 5 dependencies via 1 configured repositories.
-Chainguard SBOMs: 10 fetched, 0 not available, 0 errored.
+Resolving SBOMs for 7 dependencies via 2 configured repositories.
+Chainguard SBOMs: 14 fetched, 0 not available, 0 errored.
 ```
 
-(Five deps because Jackson pulls in two transitives.)
+(Seven deps because Jackson pulls in two transitives and log4j-core pulls
+in log4j-api.)
 
 **4. Inspect the output.**
 
@@ -123,6 +124,12 @@ build/chainguard-sboms
 ├── org/apache/commons/commons-compress/1.23.0/
 │   ├── commons-compress-1.23.0.slsa-attestation.json
 │   └── commons-compress-1.23.0.spdx.json
+├── org/apache/logging/log4j/log4j-api/2.23.1-0.cgr.1/
+│   ├── log4j-api-2.23.1-0.cgr.1.slsa-attestation.json
+│   └── log4j-api-2.23.1-0.cgr.1.spdx.json
+├── org/apache/logging/log4j/log4j-core/2.23.1-0.cgr.1/
+│   ├── log4j-core-2.23.1-0.cgr.1.slsa-attestation.json
+│   └── log4j-core-2.23.1-0.cgr.1.spdx.json
 └── org/slf4j/slf4j-api/2.0.13/
     ├── slf4j-api-2.0.13.slsa-attestation.json
     └── slf4j-api-2.0.13.spdx.json

--- a/sbom-gradle-plugin/README.md
+++ b/sbom-gradle-plugin/README.md
@@ -1,0 +1,147 @@
+# SBOM Gradle Plugin
+
+An example Gradle plugin that collects the SBOMs provided by [Chainguard's Java
+Libraries](https://edu.chainguard.dev/chainguard/libraries/java/overview/) for a
+given project.
+
+For each dependency in the resolved graph, the plugin fetches the SBOMs into
+`build/chainguard-sboms/`.
+
+See [Example](#example) for an example that demonstrates how the plugin works.
+
+## Usage
+
+To use this plugin you must either build it locally, or host it yourself in your
+own plugin repository (Artifactory, Nexus etc).
+
+```
+gradle test                # unit tests
+gradle publishToMavenLocal # install to ~/.m2/repository so mavenLocal() finds it
+```
+
+Then, apply it in your `build.gradle` like:
+
+```groovy
+plugins {
+    id 'example.chainguard.sbom' version '0.1.0-SNAPSHOT'
+}
+
+chainguardSbom {
+    formats = ['SPDX_JSON', 'SLSA_ATTESTATION']
+}
+```
+
+If you omit `formats`, it collects everything. These are the supported
+formats:
+
+- `SPDX_JSON` — SPDX SBOM (`<artifact>-<version>.spdx.json`)
+- `SLSA_ATTESTATION` — SLSA provenance (`<artifact>-<version>.slsa-attestation.json`)
+
+The plugin registers a `collectSboms` task in the `verification` group. It
+does not bind to `check` or `build` by default — invoke it explicitly with
+`gradle collectSboms`, or wire it into another task with `dependsOn` /
+`finalizedBy`.
+
+Collected files land under `build/chainguard-sboms` in a Maven-style
+directory layout — see the [example](#example) below for a full tree.
+
+## Example
+
+There is an [example project](./example) in this repository that demonstrates
+the plugin in action.
+
+### Prerequisites
+
+- JDK 11 or newer.
+- Gradle 8+.
+
+### Steps
+
+Follow these steps from this plugin's root directory (`sbom-gradle-plugin/`).
+
+**1. Mint a Chainguard Libraries pull token and export it into your shell.**
+
+Export credentials for `libraries.cgr.dev` as `CHAINGUARD_JAVA_IDENTITY_ID` and
+`CHAINGUARD_JAVA_TOKEN`.
+
+For a long-lived credential:
+
+```
+eval "$(chainctl auth pull-token create --output=env --repository=java --ttl=720h)"
+```
+
+For a short-lived credential scoped to your local Chainguard credentials:
+
+```
+export CHAINGUARD_JAVA_IDENTITY_ID=_token
+export CHAINGUARD_JAVA_TOKEN=$(chainctl auth token --audience=libraries.cgr.dev)
+```
+
+The example's `build.gradle` reads them from there.
+
+**2. Build and publish the plugin into your local Maven cache.**
+
+```
+gradle publishToMavenLocal
+```
+
+**3. Change into the example project and run the plugin.**
+
+```
+cd example
+gradle collectSboms
+```
+
+You should see something like:
+
+```
+> Task :collectSboms
+Resolving SBOMs for 5 dependencies via 1 configured repositories.
+Chainguard SBOMs: 10 fetched, 0 not available, 0 errored.
+```
+
+(Five deps because Jackson pulls in two transitives.)
+
+**4. Inspect the output.**
+
+Each dependency directory holds an SPDX SBOM and a SLSA provenance
+attestation:
+
+```
+build/chainguard-sboms
+├── com/fasterxml/jackson/core/jackson-annotations/2.17.2/
+│   ├── jackson-annotations-2.17.2.slsa-attestation.json
+│   └── jackson-annotations-2.17.2.spdx.json
+├── com/fasterxml/jackson/core/jackson-core/2.17.2/
+│   ├── jackson-core-2.17.2.slsa-attestation.json
+│   └── jackson-core-2.17.2.spdx.json
+├── com/fasterxml/jackson/core/jackson-databind/2.17.2/
+│   ├── jackson-databind-2.17.2.slsa-attestation.json
+│   └── jackson-databind-2.17.2.spdx.json
+├── org/apache/commons/commons-compress/1.23.0/
+│   ├── commons-compress-1.23.0.slsa-attestation.json
+│   └── commons-compress-1.23.0.spdx.json
+└── org/slf4j/slf4j-api/2.0.13/
+    ├── slf4j-api-2.0.13.slsa-attestation.json
+    └── slf4j-api-2.0.13.spdx.json
+```
+
+Dependencies without a Chainguard build are reported as "not available"
+in the final summary — the plugin only fetches what it can, and does not
+fail the build when a sidecar simply isn't published.
+
+## Configuration
+
+### Extension properties
+
+Configure via the `chainguardSbom { ... }` block:
+
+| Property | Default | Purpose |
+|---|---|---|
+| `outputDirectory` | `${buildDir}/chainguard-sboms` | Where SBOMs land. |
+| `formats` | *(all)* | Formats to fetch. Values: `SPDX_JSON`, `SLSA_ATTESTATION`. When empty, both are fetched. |
+| `configuration` | `runtimeClasspath` | Name of the resolvable Gradle configuration to walk. |
+| `skip` | `false` | Skip the task entirely. |
+
+Unlike the Maven equivalent, there is no `parallelism` setting — Gradle's own
+dependency resolver batches artifact downloads internally.

--- a/sbom-gradle-plugin/build.gradle
+++ b/sbom-gradle-plugin/build.gradle
@@ -1,0 +1,38 @@
+plugins {
+    id 'java-gradle-plugin'
+    id 'maven-publish'
+}
+
+group = 'example.chainguard'
+version = '0.1.0-SNAPSHOT'
+description = 'Collects SBOM sidecar files (SPDX + SLSA attestations) that Chainguard publishes next to Java library jars, using the project\'s already-configured Gradle repositories so mirrors and credentials transfer automatically.'
+
+repositories {
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+gradlePlugin {
+    plugins {
+        sbomPlugin {
+            id = 'example.chainguard.sbom'
+            implementationClass = 'example.chainguard.sbom.SbomPlugin'
+            displayName = 'Chainguard SBOM Gradle Plugin'
+            description = project.description
+        }
+    }
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/sbom-gradle-plugin/example/build.gradle
+++ b/sbom-gradle-plugin/example/build.gradle
@@ -12,10 +12,12 @@ java {
 }
 
 /*
-    Chainguard Libraries for Java is the only repository. Both jars and their
-    SBOM sidecars come from here — one endpoint, one credential. Dependencies
-    not built by Chainguard are served via upstream fallback (with malware
-    scanning + cooldown) if enabled on your account.
+Chainguard Libraries for Java provides two repository endpoints — a
+standard endpoint and a remediated endpoint that serves CVE-patched builds.
+Both jars and their SBOM sidecars come from Chainguard, using the same
+credential across both endpoints. Dependencies not built by Chainguard are
+served via upstream fallback (with malware scanning + cooldown) if enabled
+on your account.
 
     Credentials are read from environment variables so this file can be
     committed safely. Mint a pull token first:

--- a/sbom-gradle-plugin/example/build.gradle
+++ b/sbom-gradle-plugin/example/build.gradle
@@ -29,6 +29,17 @@ java {
 */
 repositories {
     maven {
+        name = 'chainguard-remediated'
+        url = 'https://libraries.cgr.dev/java-remediated/'
+        credentials {
+            username = System.getenv("CHAINGUARD_JAVA_IDENTITY_ID")
+            password = System.getenv("CHAINGUARD_JAVA_TOKEN")
+        }
+        mavenContent {
+            releasesOnly()
+        }
+    }
+    maven {
         name = 'chainguard'
         url = 'https://libraries.cgr.dev/java/'
         credentials {
@@ -47,6 +58,7 @@ dependencies {
     implementation 'org.apache.commons:commons-compress:1.23.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
     implementation 'org.slf4j:slf4j-api:2.0.13'
+    implementation 'org.apache.logging.log4j:log4j-core:2.23.1-0.cgr.1'
 }
 
 /*

--- a/sbom-gradle-plugin/example/build.gradle
+++ b/sbom-gradle-plugin/example/build.gradle
@@ -1,0 +1,55 @@
+plugins {
+    id 'java'
+    id 'example.chainguard.sbom' version '0.1.0-SNAPSHOT'
+}
+
+group = 'example.chainguard.consumer'
+version = '1.0.0-SNAPSHOT'
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+/*
+    Chainguard Libraries for Java is the only repository. Both jars and their
+    SBOM sidecars come from here — one endpoint, one credential. Dependencies
+    not built by Chainguard are served via upstream fallback (with malware
+    scanning + cooldown) if enabled on your account.
+
+    Credentials are read from environment variables so this file can be
+    committed safely. Mint a pull token first:
+
+        chainctl auth pull-token create --repository=java --ttl=720h
+
+    Then export them:
+
+        export CHAINGUARD_JAVA_IDENTITY_ID=...
+        export CHAINGUARD_JAVA_TOKEN=...
+*/
+repositories {
+    maven {
+        name = 'chainguard'
+        url = 'https://libraries.cgr.dev/java/'
+        credentials {
+            username = System.getenv("CHAINGUARD_JAVA_IDENTITY_ID")
+            password = System.getenv("CHAINGUARD_JAVA_TOKEN")
+        }
+        mavenContent {
+            releasesOnly()
+        }
+    }
+}
+
+dependencies {
+    // Chainguard's documentation uses commons-compress 1.23.0 as its canonical
+    // example of a library with SBOM/SLSA sidecars available.
+    implementation 'org.apache.commons:commons-compress:1.23.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
+    implementation 'org.slf4j:slf4j-api:2.0.13'
+}
+
+/*
+    No `chainguardSbom { ... }` block: the defaults fetch every format
+    Chainguard publishes (SPDX + SLSA attestation) into build/chainguard-sboms.
+*/

--- a/sbom-gradle-plugin/example/settings.gradle
+++ b/sbom-gradle-plugin/example/settings.gradle
@@ -1,7 +1,7 @@
 /*
     Make the locally-published plugin discoverable. `gradle publishToMavenLocal`
-    in the plugin project drops the plugin into ~/.gradle-style mavenLocal, and
-    this block tells Gradle to look there first when resolving plugin IDs.
+    in the plugin project drops the plugin into ~/.m2/repository, and this
+    block tells Gradle to look there first when resolving plugin IDs.
 */
 pluginManagement {
     repositories {

--- a/sbom-gradle-plugin/example/settings.gradle
+++ b/sbom-gradle-plugin/example/settings.gradle
@@ -1,0 +1,13 @@
+/*
+    Make the locally-published plugin discoverable. `gradle publishToMavenLocal`
+    in the plugin project drops the plugin into ~/.gradle-style mavenLocal, and
+    this block tells Gradle to look there first when resolving plugin IDs.
+*/
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = 'sbom-example'

--- a/sbom-gradle-plugin/init.gradle
+++ b/sbom-gradle-plugin/init.gradle
@@ -1,4 +1,3 @@
-def cgUrl = 'https://libraries.cgr.dev/java/'
 def cgUser = System.getenv('CHAINGUARD_JAVA_IDENTITY_ID')
 def cgPass = System.getenv('CHAINGUARD_JAVA_TOKEN')
 
@@ -8,19 +7,26 @@ if (!cgUser || !cgPass) {
         "CHAINGUARD_JAVA_TOKEN in the environment.")
 }
 
+def chainguardRepositories = { rh ->
+    rh.maven {
+        name = 'chainguard-remediated'
+        url = 'https://libraries.cgr.dev/java-remediated/'
+        credentials { username = cgUser; password = cgPass }
+        mavenContent { releasesOnly() }
+    }
+    rh.maven {
+        name = 'chainguard'
+        url = 'https://libraries.cgr.dev/java/'
+        credentials { username = cgUser; password = cgPass }
+        mavenContent { releasesOnly() }
+    }
+}
+
 gradle.beforeSettings { settings ->
     settings.pluginManagement {
         repositories {
             clear()
-            maven {
-                name = 'chainguard'
-                url = cgUrl
-                credentials {
-                    username = cgUser
-                    password = cgPass
-                }
-                mavenContent { releasesOnly() }
-            }
+            chainguardRepositories(delegate)
         }
     }
 }
@@ -28,16 +34,6 @@ gradle.beforeSettings { settings ->
 allprojects {
     afterEvaluate { project ->
         project.repositories.clear()
-        project.repositories {
-            maven {
-                name = 'chainguard'
-                url = cgUrl
-                credentials {
-                    username = cgUser
-                    password = cgPass
-                }
-                mavenContent { releasesOnly() }
-            }
-        }
+        chainguardRepositories(project.repositories)
     }
 }

--- a/sbom-gradle-plugin/init.gradle
+++ b/sbom-gradle-plugin/init.gradle
@@ -1,0 +1,43 @@
+def cgUrl = 'https://libraries.cgr.dev/java/'
+def cgUser = System.getenv('CHAINGUARD_JAVA_IDENTITY_ID')
+def cgPass = System.getenv('CHAINGUARD_JAVA_TOKEN')
+
+if (!cgUser || !cgPass) {
+    throw new GradleException(
+        "init.gradle requires CHAINGUARD_JAVA_IDENTITY_ID and " +
+        "CHAINGUARD_JAVA_TOKEN in the environment.")
+}
+
+gradle.beforeSettings { settings ->
+    settings.pluginManagement {
+        repositories {
+            clear()
+            maven {
+                name = 'chainguard'
+                url = cgUrl
+                credentials {
+                    username = cgUser
+                    password = cgPass
+                }
+                mavenContent { releasesOnly() }
+            }
+        }
+    }
+}
+
+allprojects {
+    afterEvaluate { project ->
+        project.repositories.clear()
+        project.repositories {
+            maven {
+                name = 'chainguard'
+                url = cgUrl
+                credentials {
+                    username = cgUser
+                    password = cgPass
+                }
+                mavenContent { releasesOnly() }
+            }
+        }
+    }
+}

--- a/sbom-gradle-plugin/settings.gradle
+++ b/sbom-gradle-plugin/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'sbom-gradle-plugin'

--- a/sbom-gradle-plugin/src/main/java/example/chainguard/sbom/CollectSbomsTask.java
+++ b/sbom-gradle-plugin/src/main/java/example/chainguard/sbom/CollectSbomsTask.java
@@ -1,0 +1,120 @@
+package example.chainguard.sbom;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+
+/**
+ * Walks a resolved Gradle configuration and downloads every available Chainguard
+ * sidecar (SPDX SBOM, CycloneDX SBOM, SLSA attestation) into the configured
+ * output directory. Dependencies without a Chainguard build are reported as
+ * "not available" in the final summary — the plugin only fetches what it can.
+ */
+public abstract class CollectSbomsTask extends DefaultTask {
+
+    @OutputDirectory
+    public abstract Property<File> getOutputDirectory();
+
+    @Input
+    public abstract ListProperty<Format> getFormats();
+
+    @Input
+    public abstract Property<String> getConfigurationName();
+
+    @Input
+    public abstract Property<Boolean> getSkip();
+
+    @TaskAction
+    public void collect() {
+        if (getSkip().get()) {
+            getLogger().lifecycle("collectSboms skipped by configuration.");
+            return;
+        }
+
+        String configName = getConfigurationName().get();
+        Configuration config = getProject().getConfigurations().findByName(configName);
+        if (config == null) {
+            throw new GradleException("No configuration named '" + configName + "' found on this project.");
+        }
+        if (!config.isCanBeResolved()) {
+            throw new GradleException("Configuration '" + configName + "' is not resolvable.");
+        }
+
+        List<ResolvedArtifact> artifacts = collectTargets(config);
+        if (artifacts.isEmpty()) {
+            getLogger().lifecycle("No dependencies in configuration '" + configName + "' to collect SBOMs for.");
+            return;
+        }
+
+        if (getProject().getRepositories().isEmpty()) {
+            throw new GradleException(
+                    "No repositories configured to resolve SBOMs. "
+                    + "Configure Chainguard Libraries as a repository (see "
+                    + "https://edu.chainguard.dev/chainguard/libraries/java/build-configuration/).");
+        }
+        getLogger().lifecycle("Resolving SBOMs for " + artifacts.size() + " dependencies via "
+                + getProject().getRepositories().size() + " configured repositories.");
+
+        Path outputBase = getOutputDirectory().get().toPath();
+        SbomFetcher fetcher = new SbomFetcher(getProject(), outputBase, getLogger());
+
+        List<Format> formats = effectiveFormats();
+        List<FetchResult> results = new ArrayList<>();
+        for (ResolvedArtifact a : artifacts) {
+            for (Format format : formats) {
+                results.add(fetcher.fetch(
+                        a.getModuleVersion().getId().getGroup(),
+                        a.getModuleVersion().getId().getName(),
+                        a.getModuleVersion().getId().getVersion(),
+                        a.getClassifier(),
+                        format));
+            }
+        }
+        summarize(results);
+
+        long errored = results.stream().filter(r -> r.status() == FetchResult.Status.ERROR).count();
+        if (errored > 0) {
+            throw new GradleException(errored + " SBOM fetch(es) errored (see warnings above). "
+                    + "Missing sidecars (not-available) do not fail the build; only unexpected errors do.");
+        }
+    }
+
+    private List<ResolvedArtifact> collectTargets(Configuration config) {
+        List<ResolvedArtifact> targets = new ArrayList<>();
+        for (ResolvedArtifact a : config.getResolvedConfiguration().getResolvedArtifacts()) {
+            if (!"jar".equals(a.getType())) continue;
+            targets.add(a);
+        }
+        return targets;
+    }
+
+    private List<Format> effectiveFormats() {
+        List<Format> f = getFormats().get();
+        return f == null || f.isEmpty() ? Arrays.asList(Format.values()) : f;
+    }
+
+    private void summarize(List<FetchResult> results) {
+        long fetched = results.stream().filter(r -> r.status() == FetchResult.Status.FETCHED).count();
+        long missing = results.stream().filter(r -> r.status() == FetchResult.Status.NOT_AVAILABLE).count();
+        long errored = results.stream().filter(r -> r.status() == FetchResult.Status.ERROR).count();
+        getLogger().lifecycle("Chainguard SBOMs: " + fetched + " fetched, "
+                + missing + " not available, " + errored + " errored.");
+        for (FetchResult r : results) {
+            if (r.status() == FetchResult.Status.ERROR) {
+                getLogger().warn(r.coordinate() + " [" + r.kind() + "]: " + r.errorMessage());
+            }
+        }
+    }
+}

--- a/sbom-gradle-plugin/src/main/java/example/chainguard/sbom/FetchResult.java
+++ b/sbom-gradle-plugin/src/main/java/example/chainguard/sbom/FetchResult.java
@@ -1,0 +1,38 @@
+package example.chainguard.sbom;
+
+/**
+ * Outcome of attempting to resolve one sidecar for one artifact.
+ */
+public final class FetchResult {
+
+    public enum Status { FETCHED, NOT_AVAILABLE, ERROR }
+
+    private final String coordinate;
+    private final Format kind;
+    private final Status status;
+    private final String errorMessage;
+
+    private FetchResult(String coordinate, Format kind, Status status, String errorMessage) {
+        this.coordinate = coordinate;
+        this.kind = kind;
+        this.status = status;
+        this.errorMessage = errorMessage;
+    }
+
+    public static FetchResult fetched(String coordinate, Format kind) {
+        return new FetchResult(coordinate, kind, Status.FETCHED, null);
+    }
+
+    public static FetchResult notAvailable(String coordinate, Format kind) {
+        return new FetchResult(coordinate, kind, Status.NOT_AVAILABLE, null);
+    }
+
+    public static FetchResult error(String coordinate, Format kind, String message) {
+        return new FetchResult(coordinate, kind, Status.ERROR, message);
+    }
+
+    public String coordinate() { return coordinate; }
+    public Format kind() { return kind; }
+    public Status status() { return status; }
+    public String errorMessage() { return errorMessage; }
+}

--- a/sbom-gradle-plugin/src/main/java/example/chainguard/sbom/Format.java
+++ b/sbom-gradle-plugin/src/main/java/example/chainguard/sbom/Format.java
@@ -1,0 +1,38 @@
+package example.chainguard.sbom;
+
+/**
+ * Sidecar file types published alongside Chainguard-built jars. Both use a
+ * compound extension with no classifier ({@code foo-1.0.spdx.json},
+ * {@code foo-1.0.slsa-attestation.json}). Each kind records both so callers
+ * can build a Gradle dependency notation that resolves to the right URL.
+ */
+public enum Format {
+
+    SPDX_JSON("", "spdx.json"),
+    SLSA_ATTESTATION("", "slsa-attestation.json");
+
+    private final String classifierSuffix;
+    private final String extension;
+
+    Format(String classifierSuffix, String extension) {
+        this.classifierSuffix = classifierSuffix;
+        this.extension = extension;
+    }
+
+    public String extension() {
+        return extension;
+    }
+
+    /**
+     * Compose the effective classifier for this sidecar given an artifact's own
+     * classifier. When the artifact has no classifier, the sidecar's classifier
+     * suffix is used verbatim (or empty). Otherwise the two are joined with a
+     * dash, following Maven's usual convention (Gradle's dependency notation
+     * uses the same convention when the {@code classifier} attribute is set).
+     */
+    public String classifierFor(String artifactClassifier) {
+        String base = artifactClassifier == null ? "" : artifactClassifier;
+        if (classifierSuffix.isEmpty()) return base;
+        return base.isEmpty() ? classifierSuffix : base + "-" + classifierSuffix;
+    }
+}

--- a/sbom-gradle-plugin/src/main/java/example/chainguard/sbom/SbomExtension.java
+++ b/sbom-gradle-plugin/src/main/java/example/chainguard/sbom/SbomExtension.java
@@ -1,0 +1,35 @@
+package example.chainguard.sbom;
+
+import java.io.File;
+
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+
+/**
+ * Shared configuration for the SBOM plugin. Mirrors the parameter surface of
+ * the Maven plugin's {@code AbstractSbomMojo}.
+ * <p>
+ * Note: Gradle's own dependency resolver handles fetch parallelism internally,
+ * so there is no {@code parallelism} setting equivalent to the Maven side.
+ */
+public abstract class SbomExtension {
+
+    /** Directory to write collected SBOMs into. */
+    public abstract Property<File> getOutputDirectory();
+
+    /**
+     * Sidecar formats to download for each dependency. When empty, all known
+     * formats are fetched ({@code SPDX_JSON}, {@code SLSA_ATTESTATION}).
+     */
+    public abstract ListProperty<Format> getFormats();
+
+    /**
+     * Name of the resolvable {@link org.gradle.api.artifacts.Configuration} to
+     * walk. Defaults to {@code runtimeClasspath}, analogous to the Maven
+     * plugin's default {@code compile,runtime} scope filter.
+     */
+    public abstract Property<String> getConfiguration();
+
+    /** Skip the task entirely. */
+    public abstract Property<Boolean> getSkip();
+}

--- a/sbom-gradle-plugin/src/main/java/example/chainguard/sbom/SbomFetcher.java
+++ b/sbom-gradle-plugin/src/main/java/example/chainguard/sbom/SbomFetcher.java
@@ -1,0 +1,101 @@
+package example.chainguard.sbom;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.LenientConfiguration;
+import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.logging.Logger;
+
+/**
+ * Resolves Chainguard sidecar files (SPDX SBOMs, SLSA attestations) using the
+ * project's already-configured repositories. Because we go through Gradle's own
+ * dependency resolver via a detached configuration, credentials configured on
+ * {@code MavenArtifactRepository} transfer automatically — the plugin never
+ * needs to know about {@code libraries.cgr.dev} directly.
+ */
+public final class SbomFetcher {
+
+    private final Project project;
+    private final Path outputDirectory;
+    private final Logger log;
+
+    public SbomFetcher(Project project, Path outputDirectory, Logger log) {
+        this.project = project;
+        this.outputDirectory = outputDirectory;
+        this.log = log;
+    }
+
+    public FetchResult fetch(String groupId, String artifactId, String version,
+                             String classifier, Format kind) {
+        String coord = coordinate(groupId, artifactId, classifier, version);
+
+        Map<String, Object> notation = new HashMap<>();
+        notation.put("group", groupId);
+        notation.put("name", artifactId);
+        notation.put("version", version);
+        String effectiveClassifier = kind.classifierFor(classifier);
+        if (!effectiveClassifier.isEmpty()) {
+            notation.put("classifier", effectiveClassifier);
+        }
+        notation.put("ext", kind.extension());
+
+        try {
+            Dependency dep = project.getDependencies().create(notation);
+            Configuration cfg = project.getConfigurations().detachedConfiguration(dep);
+            cfg.setTransitive(false);
+            // Lenient resolution: unresolved sidecars come back as "unresolved
+            // dependencies" rather than throwing, so we can distinguish
+            // "Chainguard didn't publish this" from real transport/IO errors.
+            LenientConfiguration lenient = cfg.getResolvedConfiguration().getLenientConfiguration();
+            if (!lenient.getUnresolvedModuleDependencies().isEmpty()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("No " + kind + " for " + coord);
+                }
+                return FetchResult.notAvailable(coord, kind);
+            }
+            Set<ResolvedArtifact> resolved = lenient.getArtifacts();
+            if (resolved.isEmpty()) {
+                return FetchResult.notAvailable(coord, kind);
+            }
+            File file = resolved.iterator().next().getFile();
+            Path dest = destinationFor(outputDirectory, groupId, artifactId, version, file.getName());
+            Files.createDirectories(dest.getParent());
+            Files.copy(file.toPath(), dest, StandardCopyOption.REPLACE_EXISTING);
+            return FetchResult.fetched(coord, kind);
+        } catch (IOException e) {
+            return FetchResult.error(coord, kind,
+                    "failed to write sidecar to " + outputDirectory + ": " + e.getMessage());
+        } catch (RuntimeException e) {
+            return FetchResult.error(coord, kind,
+                    "unexpected error resolving sidecar: " + e.getClass().getSimpleName()
+                    + ": " + e.getMessage());
+        }
+    }
+
+    static String coordinate(String groupId, String artifactId, String classifier, String version) {
+        StringBuilder sb = new StringBuilder(groupId).append(':').append(artifactId);
+        if (classifier != null && !classifier.isEmpty()) {
+            sb.append(':').append(classifier);
+        }
+        return sb.append(':').append(version).toString();
+    }
+
+    static Path destinationFor(Path outputDirectory, String groupId, String artifactId,
+                               String version, String filename) {
+        return outputDirectory
+                .resolve(groupId.replace('.', '/'))
+                .resolve(artifactId)
+                .resolve(version)
+                .resolve(filename);
+    }
+}

--- a/sbom-gradle-plugin/src/main/java/example/chainguard/sbom/SbomPlugin.java
+++ b/sbom-gradle-plugin/src/main/java/example/chainguard/sbom/SbomPlugin.java
@@ -1,0 +1,33 @@
+package example.chainguard.sbom;
+
+import java.io.File;
+import java.util.Collections;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+/**
+ * Registers the {@code chainguardSbom} extension and the {@code collectSboms}
+ * task on the applying project.
+ */
+public class SbomPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        SbomExtension ext = project.getExtensions().create("chainguardSbom", SbomExtension.class);
+        ext.getOutputDirectory().convention(
+                new File(project.getLayout().getBuildDirectory().getAsFile().get(), "chainguard-sboms"));
+        ext.getFormats().convention(Collections.emptyList());
+        ext.getConfiguration().convention("runtimeClasspath");
+        ext.getSkip().convention(false);
+
+        project.getTasks().register("collectSboms", CollectSbomsTask.class, task -> {
+            task.setGroup("verification");
+            task.setDescription("Fetch Chainguard SBOM sidecars for resolved dependencies.");
+            task.getOutputDirectory().set(ext.getOutputDirectory());
+            task.getFormats().set(ext.getFormats());
+            task.getConfigurationName().set(ext.getConfiguration());
+            task.getSkip().set(ext.getSkip());
+        });
+    }
+}

--- a/sbom-gradle-plugin/src/test/java/example/chainguard/sbom/FormatTest.java
+++ b/sbom-gradle-plugin/src/test/java/example/chainguard/sbom/FormatTest.java
@@ -1,0 +1,29 @@
+package example.chainguard.sbom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class FormatTest {
+
+    @Test
+    void spdxHasExtensionOnlyNoClassifier() {
+        assertEquals("spdx.json", Format.SPDX_JSON.extension());
+        assertEquals("", Format.SPDX_JSON.classifierFor(null));
+        assertEquals("", Format.SPDX_JSON.classifierFor(""));
+    }
+
+    @Test
+    void slsaAttestation() {
+        assertEquals("slsa-attestation.json", Format.SLSA_ATTESTATION.extension());
+        assertEquals("", Format.SLSA_ATTESTATION.classifierFor(""));
+    }
+
+    @Test
+    void classifierPassesThroughExistingArtifactClassifier() {
+        // Neither current sidecar has a classifier suffix, so an artifact
+        // classifier passes through verbatim.
+        assertEquals("sources", Format.SPDX_JSON.classifierFor("sources"));
+        assertEquals("sources", Format.SLSA_ATTESTATION.classifierFor("sources"));
+    }
+}

--- a/sbom-gradle-plugin/src/test/java/example/chainguard/sbom/SbomFetcherTest.java
+++ b/sbom-gradle-plugin/src/test/java/example/chainguard/sbom/SbomFetcherTest.java
@@ -1,0 +1,38 @@
+package example.chainguard.sbom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+class SbomFetcherTest {
+
+    @Test
+    void coordinateOmitsEmptyClassifier() {
+        assertEquals("org.apache.commons:commons-compress:1.23.0",
+                SbomFetcher.coordinate("org.apache.commons", "commons-compress", null, "1.23.0"));
+        assertEquals("org.apache.commons:commons-compress:1.23.0",
+                SbomFetcher.coordinate("org.apache.commons", "commons-compress", "", "1.23.0"));
+    }
+
+    @Test
+    void coordinateIncludesClassifierWhenPresent() {
+        assertEquals("com.example:widget:sources:1.0.0",
+                SbomFetcher.coordinate("com.example", "widget", "sources", "1.0.0"));
+    }
+
+    @Test
+    void destinationForUsesMavenLayout() {
+        Path base = Paths.get("build", "chainguard-sboms");
+        Path dest = SbomFetcher.destinationFor(base,
+                "org.apache.commons", "commons-compress", "1.23.0",
+                "commons-compress-1.23.0.spdx.json");
+        assertEquals(
+                base.resolve("org").resolve("apache").resolve("commons")
+                        .resolve("commons-compress").resolve("1.23.0")
+                        .resolve("commons-compress-1.23.0.spdx.json"),
+                dest);
+    }
+}

--- a/sbom-maven-plugin/README.md
+++ b/sbom-maven-plugin/README.md
@@ -14,9 +14,11 @@ See [Example](#example) for an example that demonstrates how the plugin works.
 To use this plugin you must either build it locally, or host it yourself in your
 own `pluginRepository` (Artifactory, Nexus etc).
 
+Export a Chainguard pull token (see [Prerequisites](#prerequisites)), then:
+
 ```
-mvn test         # unit tests
-mvn install      # install to ~/.m2/repository
+mvn -s settings.xml test         # unit tests
+mvn -s settings.xml install      # install to ~/.m2/repository
 ```
 
 Then, you can add it to your `pom.xml` like:
@@ -89,7 +91,7 @@ The example's `settings.xml` reads them from there.
 **2. Build and install the plugin into your local Maven cache.**
 
 ```
-mvn install
+mvn -s settings.xml install
 ```
 
 **3. Change into the example project and run the plugin.**

--- a/sbom-maven-plugin/README.md
+++ b/sbom-maven-plugin/README.md
@@ -105,15 +105,14 @@ You should see something like:
 
 ```
 [INFO] --- sbom:0.1.0-SNAPSHOT:collect ---
-[INFO] Resolving SBOMs for 5 dependencies via 2 configured repositories.
+[INFO] Resolving SBOMs for 7 dependencies via 3 configured repositories.
 [INFO] Downloading from chainguard: https://libraries.cgr.dev/java/org/apache/commons/commons-compress/1.23.0/commons-compress-1.23.0.spdx.json
 ...
-[INFO] Chainguard SBOMs: 10 fetched, 0 not available, 0 errored.
+[INFO] Chainguard SBOMs: 14 fetched, 0 not available, 0 errored.
 ```
 
-(Five deps because Jackson pulls in two transitives; two repositories
-because Maven adds Central by default alongside the Chainguard one
-declared in `pom.xml`.)
+(Seven deps because Jackson pulls in two transitives and log4j-core pulls
+in log4j-api.)
 
 **4. Inspect the output.**
 
@@ -134,6 +133,12 @@ target/chainguard-sboms
 ├── org/apache/commons/commons-compress/1.23.0/
 │   ├── commons-compress-1.23.0.slsa-attestation.json
 │   └── commons-compress-1.23.0.spdx.json
+├── org/apache/logging/log4j/log4j-api/2.23.1-0.cgr.1/
+│   ├── log4j-api-2.23.1-0.cgr.1.slsa-attestation.json
+│   └── log4j-api-2.23.1-0.cgr.1.spdx.json
+├── org/apache/logging/log4j/log4j-core/2.23.1-0.cgr.1/
+│   ├── log4j-core-2.23.1-0.cgr.1.slsa-attestation.json
+│   └── log4j-core-2.23.1-0.cgr.1.spdx.json
 └── org/slf4j/slf4j-api/2.0.13/
     ├── slf4j-api-2.0.13.slsa-attestation.json
     └── slf4j-api-2.0.13.spdx.json

--- a/sbom-maven-plugin/README.md
+++ b/sbom-maven-plugin/README.md
@@ -1,0 +1,157 @@
+# SBOM Maven Plugin
+
+An example Maven plugin that collects the SBOMs provided by [Chainguard's Java
+Libraries](https://edu.chainguard.dev/chainguard/libraries/java/overview/) for a
+given project.
+
+For each dependency in the resolved graph, the plugin fetches the SBOMs into
+`target/chainguard-sboms/`.
+
+See [Example](#example) for an example that demonstrates how the plugin works.
+
+## Usage
+
+To use this plugin you must either build it locally, or host it yourself in your
+own `pluginRepository` (Artifactory, Nexus etc).
+
+```
+mvn test         # unit tests
+mvn install      # install to ~/.m2/repository
+```
+
+Then, you can add it to your `pom.xml` like:
+
+```xml
+<plugin>
+    <groupId>example.chainguard</groupId>
+    <artifactId>sbom-maven-plugin</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <configuration>
+        <formats>
+            <format>SPDX_JSON</format>
+            <format>SLSA_ATTESTATION</format>
+        </formats>
+    </configuration>
+    <executions>
+        <execution>
+            <goals><goal>collect</goal></goals>
+        </execution>
+    </executions>
+</plugin>
+```
+
+If you omit the `formats`, it collects everything. These are the supported
+formats:
+
+- `SPDX_JSON` — SPDX SBOM (`<artifact>-<version>.spdx.json`)
+- `SLSA_ATTESTATION` — SLSA provenance (`<artifact>-<version>.slsa-attestation.json`)
+
+The `collect` goal binds to the `verify` phase by default, so `mvn verify`
+will emit the SBOMs. It can also be run ad-hoc with `mvn sbom:collect`.
+
+Collected files land under `target/chainguard-sboms` in a Maven-style
+directory layout — see the [example](#example) below for a full tree.
+
+## Example
+
+There is an [example project](./example) in this repository that demonstrates
+the plugin in action.
+
+### Prerequisites
+
+- JDK 11 or newer.
+- Maven 3.9+.
+
+### Steps
+
+Follow these steps from this plugin's root directory (`sbom-maven-plugin/`).
+
+**1. Mint a Chainguard Libraries pull token and export it into your shell.**
+
+Export credentials for `libraries.cgr.dev` as `CHAINGUARD_JAVA_IDENTITY_ID` and
+`CHAINGUARD_JAVA_TOKEN`.
+
+For a long-lived credential:
+
+```
+eval "$(chainctl auth pull-token create --output=env --repository=java --ttl=720h)"
+```
+
+For a short-lived credential scoped to your local Chainguard credentials:
+
+```
+export CHAINGUARD_JAVA_IDENTITY_ID=_token
+export CHAINGUARD_JAVA_TOKEN=$(chainctl auth token --audience=libraries.cgr.dev)
+```
+
+The example's `settings.xml` reads them from there.
+
+**2. Build and install the plugin into your local Maven cache.**
+
+```
+mvn install
+```
+
+**3. Change into the example project and run the plugin.**
+
+```
+cd example
+mvn -s settings.xml sbom:collect
+```
+
+You should see something like:
+
+```
+[INFO] --- sbom:0.1.0-SNAPSHOT:collect ---
+[INFO] Resolving SBOMs for 5 dependencies via 2 configured repositories.
+[INFO] Downloading from chainguard: https://libraries.cgr.dev/java/org/apache/commons/commons-compress/1.23.0/commons-compress-1.23.0.spdx.json
+...
+[INFO] Chainguard SBOMs: 10 fetched, 0 not available, 0 errored.
+```
+
+(Five deps because Jackson pulls in two transitives; two repositories
+because Maven adds Central by default alongside the Chainguard one
+declared in `pom.xml`.)
+
+**4. Inspect the output.**
+
+Each dependency directory holds an SPDX SBOM and a SLSA provenance
+attestation:
+
+```
+target/chainguard-sboms
+├── com/fasterxml/jackson/core/jackson-annotations/2.17.2/
+│   ├── jackson-annotations-2.17.2.slsa-attestation.json
+│   └── jackson-annotations-2.17.2.spdx.json
+├── com/fasterxml/jackson/core/jackson-core/2.17.2/
+│   ├── jackson-core-2.17.2.slsa-attestation.json
+│   └── jackson-core-2.17.2.spdx.json
+├── com/fasterxml/jackson/core/jackson-databind/2.17.2/
+│   ├── jackson-databind-2.17.2.slsa-attestation.json
+│   └── jackson-databind-2.17.2.spdx.json
+├── org/apache/commons/commons-compress/1.23.0/
+│   ├── commons-compress-1.23.0.slsa-attestation.json
+│   └── commons-compress-1.23.0.spdx.json
+└── org/slf4j/slf4j-api/2.0.13/
+    ├── slf4j-api-2.0.13.slsa-attestation.json
+    └── slf4j-api-2.0.13.spdx.json
+```
+
+Dependencies without a Chainguard build are reported as "not available"
+in the final summary — the plugin only fetches what it can, and does not
+fail the build when a sidecar simply isn't published.
+
+## Configuration
+
+### Parameters
+
+| Parameter | Default | Purpose |
+|---|---|---|
+| `outputDirectory` | `${project.build.directory}/chainguard-sboms` | Where SBOMs land. |
+| `formats` | *(all)* | Formats to fetch. Values: `SPDX_JSON`, `SLSA_ATTESTATION`. When unset, both are fetched. |
+| `includeScope` | `compile,runtime` | Maven scopes to walk. |
+| `parallelism` | `8` | Concurrent SBOM resolutions. |
+| `skip` | `false` | Skip the goal entirely. |
+
+Every parameter is also exposed as a system property under the
+`chainguard.sbom.*` namespace (e.g. `-Dchainguard.sbom.parallelism=16`).

--- a/sbom-maven-plugin/example/pom.xml
+++ b/sbom-maven-plugin/example/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>example.chainguard.consumer</groupId>
+    <artifactId>sbom-example</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Chainguard SBOM Plugin — example consumer</name>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <!--
+        Chainguard Libraries for Java is the only repository. Both jars and
+        their SBOM sidecars come from here — one endpoint, one credential.
+        Dependencies not built by Chainguard are served via upstream fallback
+        (with malware scanning + cooldown) if enabled on your account.
+    -->
+    <repositories>
+        <repository>
+            <id>chainguard</id>
+            <url>https://libraries.cgr.dev/java/</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+    </repositories>
+
+    <!--
+        Chainguard Libraries also serves Maven build plugins (maven-compiler-plugin,
+        maven-jar-plugin, etc.) from the same endpoint. One URL for the whole build.
+    -->
+    <pluginRepositories>
+        <pluginRepository>
+            <id>chainguard</id>
+            <url>https://libraries.cgr.dev/java/</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>false</enabled></snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <dependencies>
+        <!--
+            Chainguard's documentation uses commons-compress 1.23.0 as its
+            canonical example of a library with SBOM/SLSA sidecars available.
+        -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.23.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.17.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.13</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>example.chainguard</groupId>
+                <artifactId>sbom-maven-plugin</artifactId>
+                <version>0.1.0-SNAPSHOT</version>
+                <!-- No <configuration> block: the default fetches every format
+                     Chainguard publishes (SPDX + SLSA attestation). -->
+                <executions>
+                    <execution>
+                        <id>collect-sboms</id>
+                        <goals><goal>collect</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sbom-maven-plugin/example/pom.xml
+++ b/sbom-maven-plugin/example/pom.xml
@@ -25,6 +25,12 @@
     -->
     <repositories>
         <repository>
+            <id>chainguard-remediated</id>
+            <url>https://libraries.cgr.dev/java-remediated/</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>false</enabled></snapshots>
+        </repository>
+        <repository>
             <id>chainguard</id>
             <url>https://libraries.cgr.dev/java/</url>
             <releases><enabled>true</enabled></releases>
@@ -37,6 +43,12 @@
         maven-jar-plugin, etc.) from the same endpoint. One URL for the whole build.
     -->
     <pluginRepositories>
+        <pluginRepository>
+            <id>chainguard-remediated</id>
+            <url>https://libraries.cgr.dev/java-remediated/</url>
+            <releases><enabled>true</enabled></releases>
+            <snapshots><enabled>false</enabled></snapshots>
+        </pluginRepository>
         <pluginRepository>
             <id>chainguard</id>
             <url>https://libraries.cgr.dev/java/</url>
@@ -64,6 +76,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>2.0.13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.23.1-0.cgr.1</version>
         </dependency>
     </dependencies>
 

--- a/sbom-maven-plugin/example/settings.xml
+++ b/sbom-maven-plugin/example/settings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Credentials for the Chainguard Libraries repository. Values are read from
+    environment variables so this file can be committed safely. See the plugin
+    README for how to mint a pull token and export CHAINGUARD_JAVA_IDENTITY_ID
+    and CHAINGUARD_JAVA_TOKEN before running mvn.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+    <servers>
+        <server>
+            <id>chainguard</id>
+            <username>${env.CHAINGUARD_JAVA_IDENTITY_ID}</username>
+            <password>${env.CHAINGUARD_JAVA_TOKEN}</password>
+        </server>
+    </servers>
+</settings>

--- a/sbom-maven-plugin/example/settings.xml
+++ b/sbom-maven-plugin/example/settings.xml
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Credentials for the Chainguard Libraries repository. Values are read from
+    Credentials for the Chainguard Libraries repositories. Values are read from
     environment variables so this file can be committed safely. See the plugin
     README for how to mint a pull token and export CHAINGUARD_JAVA_IDENTITY_ID
     and CHAINGUARD_JAVA_TOKEN before running mvn.
 -->
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
     <servers>
+        <server>
+            <id>chainguard-remediated</id>
+            <username>${env.CHAINGUARD_JAVA_IDENTITY_ID}</username>
+            <password>${env.CHAINGUARD_JAVA_TOKEN}</password>
+        </server>
         <server>
             <id>chainguard</id>
             <username>${env.CHAINGUARD_JAVA_IDENTITY_ID}</username>

--- a/sbom-maven-plugin/pom.xml
+++ b/sbom-maven-plugin/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>example.chainguard</groupId>
+    <artifactId>sbom-maven-plugin</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+
+    <name>Chainguard SBOM Maven Plugin</name>
+    <description>
+        Collects SBOM sidecar files (SPDX + SLSA attestations) that Chainguard
+        publishes next to Java library jars, using the project's already-configured
+        Maven repositories so mirrors, proxies, and credentials transfer automatically.
+    </description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+
+        <maven.version>3.9.6</maven.version>
+        <maven-plugin-plugin.version>3.13.0</maven-plugin-plugin.version>
+        <maven-plugin-annotations.version>3.13.0</maven-plugin-annotations.version>
+        <maven-resolver.version>1.9.18</maven-resolver.version>
+        <junit.version>5.10.2</junit.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>${maven-plugin-annotations.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-api</artifactId>
+            <version>${maven-resolver.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-util</artifactId>
+            <version>${maven-resolver.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>${maven-plugin-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sbom-maven-plugin/settings.xml
+++ b/sbom-maven-plugin/settings.xml
@@ -2,18 +2,61 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
     <servers>
         <server>
+            <id>chainguard-remediated</id>
+            <username>${env.CHAINGUARD_JAVA_IDENTITY_ID}</username>
+            <password>${env.CHAINGUARD_JAVA_TOKEN}</password>
+        </server>
+        <server>
             <id>chainguard</id>
             <username>${env.CHAINGUARD_JAVA_IDENTITY_ID}</username>
             <password>${env.CHAINGUARD_JAVA_TOKEN}</password>
         </server>
     </servers>
 
+    <profiles>
+        <profile>
+            <id>chainguard</id>
+            <repositories>
+                <repository>
+                    <id>chainguard-remediated</id>
+                    <url>https://libraries.cgr.dev/java-remediated/</url>
+                    <releases><enabled>true</enabled></releases>
+                    <snapshots><enabled>false</enabled></snapshots>
+                </repository>
+                <repository>
+                    <id>chainguard</id>
+                    <url>https://libraries.cgr.dev/java/</url>
+                    <releases><enabled>true</enabled></releases>
+                    <snapshots><enabled>false</enabled></snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>chainguard-remediated</id>
+                    <url>https://libraries.cgr.dev/java-remediated/</url>
+                    <releases><enabled>true</enabled></releases>
+                    <snapshots><enabled>false</enabled></snapshots>
+                </pluginRepository>
+                <pluginRepository>
+                    <id>chainguard</id>
+                    <url>https://libraries.cgr.dev/java/</url>
+                    <releases><enabled>true</enabled></releases>
+                    <snapshots><enabled>false</enabled></snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+
+    <activeProfiles>
+        <activeProfile>chainguard</activeProfile>
+    </activeProfiles>
+
     <mirrors>
         <mirror>
             <id>chainguard</id>
             <name>Chainguard Libraries for Java</name>
             <url>https://libraries.cgr.dev/java/</url>
-            <mirrorOf>*</mirrorOf>
+            <mirrorOf>external:*,!chainguard,!chainguard-remediated</mirrorOf>
         </mirror>
     </mirrors>
 </settings>

--- a/sbom-maven-plugin/settings.xml
+++ b/sbom-maven-plugin/settings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+    <servers>
+        <server>
+            <id>chainguard</id>
+            <username>${env.CHAINGUARD_JAVA_IDENTITY_ID}</username>
+            <password>${env.CHAINGUARD_JAVA_TOKEN}</password>
+        </server>
+    </servers>
+
+    <mirrors>
+        <mirror>
+            <id>chainguard</id>
+            <name>Chainguard Libraries for Java</name>
+            <url>https://libraries.cgr.dev/java/</url>
+            <mirrorOf>*</mirrorOf>
+        </mirror>
+    </mirrors>
+</settings>

--- a/sbom-maven-plugin/src/main/java/example/chainguard/sbom/AbstractSbomMojo.java
+++ b/sbom-maven-plugin/src/main/java/example/chainguard/sbom/AbstractSbomMojo.java
@@ -1,0 +1,65 @@
+package example.chainguard.sbom;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+
+/**
+ * Shared configuration and Maven/Aether wiring for the SBOM mojo.
+ */
+public abstract class AbstractSbomMojo extends AbstractMojo {
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    protected MavenProject project;
+
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
+    protected RepositorySystemSession repoSession;
+
+    @Component
+    protected RepositorySystem repoSystem;
+
+    /**
+     * Directory to write collected SBOMs into.
+     */
+    @Parameter(defaultValue = "${project.build.directory}/chainguard-sboms", property = "chainguard.sbom.outputDirectory")
+    protected File outputDirectory;
+
+    /**
+     * Sidecar formats to download for each dependency. When unset, all known
+     * formats are fetched ({@code SPDX_JSON}, {@code SLSA_ATTESTATION}). Set
+     * an explicit list to restrict.
+     */
+    @Parameter(property = "chainguard.sbom.formats")
+    protected List<Format> formats;
+
+    protected List<Format> effectiveFormats() {
+        return formats == null || formats.isEmpty()
+                ? Arrays.asList(Format.values())
+                : formats;
+    }
+
+    /**
+     * Maven scopes to include when walking the resolved dependency graph.
+     */
+    @Parameter(defaultValue = "compile,runtime", property = "chainguard.sbom.includeScope")
+    protected String includeScope;
+
+    /**
+     * Number of concurrent SBOM fetches.
+     */
+    @Parameter(defaultValue = "8", property = "chainguard.sbom.parallelism")
+    protected int parallelism;
+
+    /**
+     * Skip the goal entirely.
+     */
+    @Parameter(defaultValue = "false", property = "chainguard.sbom.skip")
+    protected boolean skip;
+}

--- a/sbom-maven-plugin/src/main/java/example/chainguard/sbom/CollectSbomMojo.java
+++ b/sbom-maven-plugin/src/main/java/example/chainguard/sbom/CollectSbomMojo.java
@@ -1,0 +1,154 @@
+package example.chainguard.sbom;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.eclipse.aether.repository.RemoteRepository;
+
+/**
+ * Walks the resolved dependency graph and downloads every available Chainguard
+ * sidecar (SPDX SBOM, CycloneDX SBOM, SLSA attestation) into the configured
+ * output directory. Dependencies without a Chainguard build are skipped
+ * silently — the plugin only fetches what it can.
+ */
+@Mojo(name = "collect",
+      defaultPhase = LifecyclePhase.VERIFY,
+      requiresDependencyResolution = ResolutionScope.RUNTIME,
+      threadSafe = true)
+public class CollectSbomMojo extends AbstractSbomMojo {
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().info("sbom:collect skipped by configuration.");
+            return;
+        }
+
+        Set<String> scopes = parseScopes(includeScope);
+        List<Artifact> targets = collectTargets(scopes);
+
+        if (targets.isEmpty()) {
+            getLog().info("No dependencies in scope " + scopes + " to collect SBOMs for.");
+            return;
+        }
+
+        List<RemoteRepository> repos = project.getRemoteProjectRepositories();
+        if (repos == null || repos.isEmpty()) {
+            throw new MojoFailureException(
+                    "No remote repositories are available to resolve SBOMs. "
+                    + "Configure Chainguard Libraries as a repository (see "
+                    + "https://edu.chainguard.dev/chainguard/libraries/java/build-configuration/).");
+        }
+        getLog().info("Resolving SBOMs for " + targets.size() + " dependencies via "
+                + repos.size() + " configured repositories.");
+
+        Path outputBase = outputDirectory.toPath();
+        SbomFetcher fetcher = new SbomFetcher(repoSystem, repoSession, repos, outputBase, getLog());
+
+        List<Format> formats = effectiveFormats();
+        List<FetchResult> results = fetchAll(targets, formats, fetcher);
+        summarize(results);
+
+        long errored = results.stream().filter(r -> r.status() == FetchResult.Status.ERROR).count();
+        if (errored > 0) {
+            throw new MojoFailureException(errored + " SBOM fetch(es) errored (see warnings above). "
+                    + "Missing sidecars (not-available) do not fail the build; only unexpected errors do.");
+        }
+    }
+
+    private List<Artifact> collectTargets(Set<String> scopes) {
+        List<Artifact> targets = new ArrayList<>();
+        Collection<Artifact> deps = project.getArtifacts();
+        if (deps != null) {
+            for (Artifact a : deps) {
+                if (!scopes.contains(a.getScope())) continue;
+                if (!"jar".equals(a.getType())) continue;
+                targets.add(a);
+            }
+        }
+        return targets;
+    }
+
+    private List<FetchResult> fetchAll(List<Artifact> targets, List<Format> formats, SbomFetcher fetcher)
+            throws MojoExecutionException, MojoFailureException {
+        int threads = Math.max(1, parallelism);
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            List<CompletableFuture<FetchResult>> futures = new ArrayList<>();
+            for (Artifact a : targets) {
+                for (Format format : formats) {
+                    futures.add(CompletableFuture.supplyAsync(
+                            () -> fetcher.fetch(a.getGroupId(), a.getArtifactId(), a.getVersion(),
+                                    a.getClassifier(), format),
+                            pool));
+                }
+            }
+            List<FetchResult> results = new ArrayList<>(futures.size());
+            try {
+                for (CompletableFuture<FetchResult> f : futures) {
+                    results.add(f.get());
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                futures.forEach(f -> f.cancel(true));
+                throw new MojoFailureException("Interrupted while resolving SBOMs", e);
+            } catch (ExecutionException e) {
+                // SbomFetcher.fetch catches everything it throws, so this only fires
+                // for a truly unexpected failure (JVM error, task cancellation, etc.).
+                throw new MojoExecutionException("Unexpected failure resolving SBOM", e.getCause());
+            }
+            return results;
+        } finally {
+            pool.shutdown();
+            try {
+                if (!pool.awaitTermination(10, TimeUnit.SECONDS)) {
+                    pool.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                pool.shutdownNow();
+            }
+        }
+    }
+
+    private void summarize(List<FetchResult> results) {
+        long fetched = results.stream().filter(r -> r.status() == FetchResult.Status.FETCHED).count();
+        long missing = results.stream().filter(r -> r.status() == FetchResult.Status.NOT_AVAILABLE).count();
+        long errored = results.stream().filter(r -> r.status() == FetchResult.Status.ERROR).count();
+        getLog().info("Chainguard SBOMs: " + fetched + " fetched, "
+                + missing + " not available, " + errored + " errored.");
+        for (FetchResult r : results) {
+            if (r.status() == FetchResult.Status.ERROR) {
+                getLog().warn(r.coordinate() + " [" + r.kind() + "]: " + r.errorMessage());
+            }
+        }
+    }
+
+    private static Set<String> parseScopes(String value) {
+        if (value == null || value.isEmpty()) {
+            return new HashSet<>(Arrays.asList("compile", "runtime"));
+        }
+        return Arrays.stream(value.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(s -> s.toLowerCase(java.util.Locale.ROOT))
+                .collect(Collectors.toCollection(HashSet::new));
+    }
+}

--- a/sbom-maven-plugin/src/main/java/example/chainguard/sbom/FetchResult.java
+++ b/sbom-maven-plugin/src/main/java/example/chainguard/sbom/FetchResult.java
@@ -1,0 +1,38 @@
+package example.chainguard.sbom;
+
+/**
+ * Outcome of attempting to resolve one sidecar for one artifact.
+ */
+public final class FetchResult {
+
+    public enum Status { FETCHED, NOT_AVAILABLE, ERROR }
+
+    private final String coordinate;
+    private final Format kind;
+    private final Status status;
+    private final String errorMessage;
+
+    private FetchResult(String coordinate, Format kind, Status status, String errorMessage) {
+        this.coordinate = coordinate;
+        this.kind = kind;
+        this.status = status;
+        this.errorMessage = errorMessage;
+    }
+
+    public static FetchResult fetched(String coordinate, Format kind) {
+        return new FetchResult(coordinate, kind, Status.FETCHED, null);
+    }
+
+    public static FetchResult notAvailable(String coordinate, Format kind) {
+        return new FetchResult(coordinate, kind, Status.NOT_AVAILABLE, null);
+    }
+
+    public static FetchResult error(String coordinate, Format kind, String message) {
+        return new FetchResult(coordinate, kind, Status.ERROR, message);
+    }
+
+    public String coordinate() { return coordinate; }
+    public Format kind() { return kind; }
+    public Status status() { return status; }
+    public String errorMessage() { return errorMessage; }
+}

--- a/sbom-maven-plugin/src/main/java/example/chainguard/sbom/Format.java
+++ b/sbom-maven-plugin/src/main/java/example/chainguard/sbom/Format.java
@@ -1,0 +1,37 @@
+package example.chainguard.sbom;
+
+/**
+ * Sidecar file types published alongside Chainguard-built jars. Both use a
+ * compound extension with no classifier ({@code foo-1.0.spdx.json},
+ * {@code foo-1.0.slsa-attestation.json}). Each kind records both so callers
+ * can build a Maven {@code Artifact} coordinate that resolves to the right URL.
+ */
+public enum Format {
+
+    SPDX_JSON("", "spdx.json"),
+    SLSA_ATTESTATION("", "slsa-attestation.json");
+
+    private final String classifierSuffix;
+    private final String extension;
+
+    Format(String classifierSuffix, String extension) {
+        this.classifierSuffix = classifierSuffix;
+        this.extension = extension;
+    }
+
+    public String extension() {
+        return extension;
+    }
+
+    /**
+     * Compose the effective Maven classifier for this sidecar given an
+     * artifact's own classifier. When the artifact has no classifier, the
+     * sidecar's classifier suffix is used verbatim (or empty). Otherwise the
+     * two are joined with a dash, following Maven's usual convention.
+     */
+    public String classifierFor(String artifactClassifier) {
+        String base = artifactClassifier == null ? "" : artifactClassifier;
+        if (classifierSuffix.isEmpty()) return base;
+        return base.isEmpty() ? classifierSuffix : base + "-" + classifierSuffix;
+    }
+}

--- a/sbom-maven-plugin/src/main/java/example/chainguard/sbom/SbomFetcher.java
+++ b/sbom-maven-plugin/src/main/java/example/chainguard/sbom/SbomFetcher.java
@@ -1,0 +1,126 @@
+package example.chainguard.sbom;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.maven.plugin.logging.Log;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.RepositoryPolicy;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+
+/**
+ * Resolves Chainguard sidecar files (SPDX SBOMs, SLSA attestations) using the
+ * project's already-configured remote repositories. Because we go through Aether,
+ * mirrors, proxies, and {@code <server>} credentials from settings.xml transfer
+ * automatically — the plugin never needs to know about libraries.cgr.dev directly.
+ */
+public final class SbomFetcher {
+
+    private final RepositorySystem repoSystem;
+    private final RepositorySystemSession session;
+    private final List<RemoteRepository> repositories;
+    private final Path outputDirectory;
+    private final Log log;
+
+    public SbomFetcher(RepositorySystem repoSystem,
+                       RepositorySystemSession session,
+                       List<RemoteRepository> repositories,
+                       Path outputDirectory,
+                       Log log) {
+        this.repoSystem = repoSystem;
+        this.session = session;
+        this.repositories = withIgnoredChecksums(repositories);
+        this.outputDirectory = outputDirectory;
+        this.log = log;
+    }
+
+    public FetchResult fetch(String groupId, String artifactId, String version,
+                             String classifier, Format kind) {
+        String coord = coordinate(groupId, artifactId, classifier, version);
+        Artifact sidecar = new DefaultArtifact(
+                groupId,
+                artifactId,
+                kind.classifierFor(classifier),
+                kind.extension(),
+                version);
+
+        ArtifactRequest request = new ArtifactRequest(sidecar, repositories, null);
+
+        try {
+            ArtifactResult result = repoSystem.resolveArtifact(session, request);
+            Path resolved = result.getArtifact().getFile().toPath();
+            Path dest = destinationFor(outputDirectory, groupId, artifactId, version, resolved.getFileName().toString());
+            Files.createDirectories(dest.getParent());
+            Files.copy(resolved, dest, StandardCopyOption.REPLACE_EXISTING);
+            return FetchResult.fetched(coord, kind);
+        } catch (ArtifactResolutionException e) {
+            // Any repo could have served it; none did. Treat as "no Chainguard SBOM
+            // exists for this dep" rather than a build failure.
+            if (log.isDebugEnabled()) {
+                log.debug("No " + kind + " for " + coord + ": " + e.getMessage());
+            }
+            return FetchResult.notAvailable(coord, kind);
+        } catch (IOException e) {
+            return FetchResult.error(coord, kind,
+                    "failed to write sidecar to " + outputDirectory + ": " + e.getMessage());
+        } catch (RuntimeException e) {
+            return FetchResult.error(coord, kind,
+                    "unexpected error resolving sidecar: " + e.getClass().getSimpleName()
+                    + ": " + e.getMessage());
+        }
+    }
+
+    static String coordinate(String groupId, String artifactId, String classifier, String version) {
+        StringBuilder sb = new StringBuilder(groupId).append(':').append(artifactId);
+        if (classifier != null && !classifier.isEmpty()) {
+            sb.append(':').append(classifier);
+        }
+        return sb.append(':').append(version).toString();
+    }
+
+    static Path destinationFor(Path outputDirectory, String groupId, String artifactId,
+                               String version, String filename) {
+        return outputDirectory
+                .resolve(groupId.replace('.', '/'))
+                .resolve(artifactId)
+                .resolve(version)
+                .resolve(filename);
+    }
+
+    /**
+     * Sidecar files may not have {@code .sha1}/{@code .md5} companions published
+     * alongside them (unlike jars). Force checksum policy to {@code ignore} so we
+     * don't emit spurious warnings on every resolution — the sidecar's authenticity
+     * is established by cosign signature verification, not by Maven checksums.
+     */
+    static List<RemoteRepository> withIgnoredChecksums(List<RemoteRepository> repos) {
+        return repos.stream()
+                .map(SbomFetcher::relaxChecksums)
+                .collect(Collectors.toList());
+    }
+
+    private static RemoteRepository relaxChecksums(RemoteRepository repo) {
+        RepositoryPolicy releases = repo.getPolicy(false);
+        RepositoryPolicy snapshots = repo.getPolicy(true);
+        return new RemoteRepository.Builder(repo)
+                .setReleasePolicy(new RepositoryPolicy(
+                        releases.isEnabled(),
+                        releases.getUpdatePolicy(),
+                        RepositoryPolicy.CHECKSUM_POLICY_IGNORE))
+                .setSnapshotPolicy(new RepositoryPolicy(
+                        snapshots.isEnabled(),
+                        snapshots.getUpdatePolicy(),
+                        RepositoryPolicy.CHECKSUM_POLICY_IGNORE))
+                .build();
+    }
+}

--- a/sbom-maven-plugin/src/test/java/example/chainguard/sbom/FormatTest.java
+++ b/sbom-maven-plugin/src/test/java/example/chainguard/sbom/FormatTest.java
@@ -1,0 +1,29 @@
+package example.chainguard.sbom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class FormatTest {
+
+    @Test
+    void spdxHasExtensionOnlyNoClassifier() {
+        assertEquals("spdx.json", Format.SPDX_JSON.extension());
+        assertEquals("", Format.SPDX_JSON.classifierFor(null));
+        assertEquals("", Format.SPDX_JSON.classifierFor(""));
+    }
+
+    @Test
+    void slsaAttestation() {
+        assertEquals("slsa-attestation.json", Format.SLSA_ATTESTATION.extension());
+        assertEquals("", Format.SLSA_ATTESTATION.classifierFor(""));
+    }
+
+    @Test
+    void classifierPassesThroughExistingArtifactClassifier() {
+        // Neither current sidecar has a classifier suffix, so an artifact
+        // classifier passes through verbatim.
+        assertEquals("sources", Format.SPDX_JSON.classifierFor("sources"));
+        assertEquals("sources", Format.SLSA_ATTESTATION.classifierFor("sources"));
+    }
+}

--- a/sbom-maven-plugin/src/test/java/example/chainguard/sbom/SbomFetcherTest.java
+++ b/sbom-maven-plugin/src/test/java/example/chainguard/sbom/SbomFetcherTest.java
@@ -1,0 +1,72 @@
+package example.chainguard.sbom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.RepositoryPolicy;
+import org.junit.jupiter.api.Test;
+
+class SbomFetcherTest {
+
+    @Test
+    void coordinateOmitsEmptyClassifier() {
+        assertEquals("org.apache.commons:commons-compress:1.23.0",
+                SbomFetcher.coordinate("org.apache.commons", "commons-compress", null, "1.23.0"));
+        assertEquals("org.apache.commons:commons-compress:1.23.0",
+                SbomFetcher.coordinate("org.apache.commons", "commons-compress", "", "1.23.0"));
+    }
+
+    @Test
+    void coordinateIncludesClassifierWhenPresent() {
+        assertEquals("com.example:widget:sources:1.0.0",
+                SbomFetcher.coordinate("com.example", "widget", "sources", "1.0.0"));
+    }
+
+    @Test
+    void destinationForUsesMavenLayout() {
+        Path base = Paths.get("target", "chainguard-sboms");
+        Path dest = SbomFetcher.destinationFor(base,
+                "org.apache.commons", "commons-compress", "1.23.0",
+                "commons-compress-1.23.0.spdx.json");
+        assertEquals(
+                base.resolve("org").resolve("apache").resolve("commons")
+                        .resolve("commons-compress").resolve("1.23.0")
+                        .resolve("commons-compress-1.23.0.spdx.json"),
+                dest);
+    }
+
+    @Test
+    void withIgnoredChecksumsRewritesBothPolicies() {
+        RemoteRepository input = new RemoteRepository.Builder("chainguard", "default", "https://libraries.cgr.dev/java/")
+                .setReleasePolicy(new RepositoryPolicy(true,
+                        RepositoryPolicy.UPDATE_POLICY_DAILY,
+                        RepositoryPolicy.CHECKSUM_POLICY_FAIL))
+                .setSnapshotPolicy(new RepositoryPolicy(false,
+                        RepositoryPolicy.UPDATE_POLICY_NEVER,
+                        RepositoryPolicy.CHECKSUM_POLICY_WARN))
+                .build();
+
+        List<RemoteRepository> out = SbomFetcher.withIgnoredChecksums(Arrays.asList(input));
+
+        assertEquals(1, out.size());
+        RemoteRepository relaxed = out.get(0);
+        assertNotSame(input, relaxed);
+        assertEquals(RepositoryPolicy.CHECKSUM_POLICY_IGNORE,
+                relaxed.getPolicy(false).getChecksumPolicy());
+        assertEquals(RepositoryPolicy.CHECKSUM_POLICY_IGNORE,
+                relaxed.getPolicy(true).getChecksumPolicy());
+        // Other policy attributes (enabled, update policy) must be preserved.
+        assertEquals(true, relaxed.getPolicy(false).isEnabled());
+        assertEquals(RepositoryPolicy.UPDATE_POLICY_DAILY,
+                relaxed.getPolicy(false).getUpdatePolicy());
+        assertEquals(false, relaxed.getPolicy(true).isEnabled());
+        assertEquals(RepositoryPolicy.UPDATE_POLICY_NEVER,
+                relaxed.getPolicy(true).getUpdatePolicy());
+    }
+}


### PR DESCRIPTION
Examples of plugins that fetch the SBOMs and attestations from alongside Chainguard libraries.